### PR TITLE
only fetch the id when handling /api/reports_from_id/

### DIFF
--- a/lib/Test/Smoke/Gateway.pm
+++ b/lib/Test/Smoke/Gateway.pm
@@ -78,6 +78,7 @@ sub api_get_reports_from_id {
         {
             order_by => { -asc => 'id' },
             rows     => $limit,
+            columns  => [ "id" ],
         }
     );
     return [map $_->id, $reports->all()];


### PR DESCRIPTION
It means we're not loading potentially large logs into memory too.

untested.